### PR TITLE
修复fieldValue为空时,异常信息提示错误.

### DIFF
--- a/jt-808-server-support/src/main/java/io/github/hylexus/jt/jt808/support/annotation/codec/Jt808AnnotationBasedEncoder.java
+++ b/jt-808-server-support/src/main/java/io/github/hylexus/jt/jt808/support/annotation/codec/Jt808AnnotationBasedEncoder.java
@@ -135,6 +135,9 @@ public class Jt808AnnotationBasedEncoder {
         }
         // 2. LIST
         if (jtDataType == MsgDataType.LIST) {
+            if (fieldValue == null) {
+                throw new NullPointerException("fieldValue == null");
+            }
             if (!(fieldValue instanceof Iterable)) {
                 throw new JtIllegalArgumentException(fieldMetadata.getFieldType().getName() + " should be Iterable");
             }


### PR DESCRIPTION
fieldValue为空时,会提示: "java.util.List should be Iterable; nested exception is io.github.hylexus.jt.exception.JtIllegalArgumentException: java.util.List should be Iterable",但实际原因为fieldValue为空.